### PR TITLE
Remove warning in Net::IMAP::Message.data

### DIFF
--- a/lib/Net/IMAP/Message.pm6
+++ b/lib/Net/IMAP/Message.pm6
@@ -40,8 +40,8 @@ method data {
         fail "Bad fetch" unless $resp ~~ /\w+\hOK\N+$/;
 
         my @lines = $resp.split("\r\n");
-        my $bytes;
-        my $seenbytes;
+        my $bytes = 0;
+        my $seenbytes = 0;
         my $data;
         for @lines {
             if /^\* \s+ \d+ \s+ FETCH .+ BODY\[\] \s+ \{(\d+)\}/ {


### PR DESCRIPTION
use of uninitialized value of type Any in numeric context  in block
at lib/Net/IMAP/Message.pm6:51

Haven't added a test for it because I'm not sure how, still not familiar with the project and lazy :)