### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Net/IMAP.pm6
+++ b/lib/Net/IMAP.pm6
@@ -1,4 +1,4 @@
-class Net::IMAP;
+unit class Net::IMAP;
 
 use Net::IMAP::Raw;
 use Net::IMAP::Simple;

--- a/lib/Net/IMAP/Message.pm6
+++ b/lib/Net/IMAP/Message.pm6
@@ -1,4 +1,4 @@
-class Net::IMAP::Message;
+unit class Net::IMAP::Message;
 
 use Email::MIME;
 

--- a/lib/Net/IMAP/Raw.pm6
+++ b/lib/Net/IMAP/Raw.pm6
@@ -1,4 +1,4 @@
-class Net::IMAP::Raw;
+unit class Net::IMAP::Raw;
 
 has $.conn is rw;
 has $.reqcode is rw = 'aaaa';

--- a/lib/Net/IMAP/Simple.pm6
+++ b/lib/Net/IMAP/Simple.pm6
@@ -1,4 +1,4 @@
-class Net::IMAP::Simple;
+unit class Net::IMAP::Simple;
 
 use Net::IMAP::Message;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.